### PR TITLE
Update settings to new versions of vscode-lldb

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,16 +8,15 @@
     ],
 
     "settings": {
-		"lldb.adapterType": "bundled",
-		"lldb.executable": "/usr/bin/lldb",
-		"terminal.integrated.shell.linux": "/bin/bash"
-	},
+        "lldb.library": "/usr/lib/liblldb.so",
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
 
     // Uncomment the next line if you want to publish any ports.
-	// "appPort": [],
+    // "appPort": [],
 
     "extensions": [
-		"pvasek.sourcekit-lsp--dev-unofficial",
-		"vadimcn.vscode-lldb"
-	]
+        "pvasek.sourcekit-lsp--dev-unofficial",
+        "vadimcn.vscode-lldb"
+    ]
 }


### PR DESCRIPTION
The adapterType setting has been retired, and using a specific
lldb needs pointing to the library, no longer the executable.
